### PR TITLE
[DateTimePicker] set TimeSelector background to Transparent

### DIFF
--- a/SourceCode/SharedResources/Panuon.WPF.UI.Internal/Styles/DateTimePickerStyle.xaml
+++ b/SourceCode/SharedResources/Panuon.WPF.UI.Internal/Styles/DateTimePickerStyle.xaml
@@ -108,6 +108,8 @@
                 Value="{Binding ActualHeight, RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="Height"
                 Value="NaN" />
+        <Setter Property="Background"
+                Value="Transparent" />
         <Setter Property="BorderThickness"
                 Value="0" />
         <Setter Property="ItemsForeground"


### PR DESCRIPTION
Fix DropDownHelper.Background has no effect on TimeSelector